### PR TITLE
Fix Java installation for macOS and update to beta.7

### DIFF
--- a/.github/changelogs/v2.0.0-beta.7.md
+++ b/.github/changelogs/v2.0.0-beta.7.md
@@ -3,3 +3,9 @@
 ### Bug fixes
 
 - Fixed an issue where EML Lib was not installing Java correctly under macOS.
+- Hiding access token in launch debug logs.
+- Code cleanup
+
+### Known issues
+
+- ETA while downloading is not accurate.

--- a/.github/changelogs/v2.0.0-beta.7.md
+++ b/.github/changelogs/v2.0.0-beta.7.md
@@ -1,0 +1,5 @@
+## Change Logs
+
+### Bug fixes
+
+- Fixed an issue where EML Lib was not installing Java correctly under macOS.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 GoldFrite
+Copyright (c) 2025 GoldFrite
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [<img src="https://img.shields.io/badge/Discord-EML-5561e6?&style=for-the-badge">](https://discord.gg/YVB4k6HzAY)
 [<img src="https://img.shields.io/badge/platforms-Windows%2C%20macOS%2C%20Linux-0077DA?style=for-the-badge&color=0077DA">](#platforms)
-[<img src="https://img.shields.io/badge/version-2.0.0--beta.6-orangered?style=for-the-badge&color=orangered">](package.json)
+[<img src="https://img.shields.io/badge/version-2.0.0--beta.7-orangered?style=for-the-badge&color=orangered">](package.json)
 
 ---
 
@@ -69,7 +69,12 @@ Please refer to the [wiki](https://github.com/Electron-Minecraft-Launcher/EML-Li
 | Others                     | Not officially | -                          |
 
 > [!WARNING]
+> Mac with Apple Silicon (M1, M2, etc.) is supported only for Minecraft 1.19 and above.
+
+> [!WARNING]
 > No support will be provided for older versions of Windows, macOS and Linux, or for other operating systems.
+
+
 
 ## Tests
 
@@ -81,6 +86,16 @@ The library have been tested on:
     <th>OS</th>
     <th>Loader</th>
     <th>Result</th>
+  </tr>
+  <tr>
+    <td rowspan="2">1.21.10</td>
+    <td rowspan="2">macOS Tahoe 26.1 (M3)</td>
+    <td>Vanilla</td>
+    <td>OK</td>
+  </tr>
+  <tr>
+    <td>Forge (60.0.12)</td>
+    <td>OK</td>
   </tr>
   <tr>
     <td rowspan="2">1.21.1</td>
@@ -100,6 +115,12 @@ The library have been tested on:
   </tr>
   <tr>
     <td>Forge (45.3.0)</td>
+    <td>OK</td>
+  </tr>
+  <tr>
+    <td>1.19</td>
+    <td>macOS Tahoe 26.1 (M3)</td>
+    <td>Forge (41.1.0)</td>
     <td>OK</td>
   </tr>
   <tr>
@@ -198,3 +219,4 @@ Please indicate the following information in your issue:
 <br>
 
 [^1]: Requires [EML AdminTool](https://github.com/Electron-Minecraft-Launcher/EML-AdminTool-v2).
+

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ import Launcher from './lib/launcher/launcher'
  *
  * @version 2.0.0-7
  * @license MIT — See the `LICENSE` file for more information
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 declare namespace EMLLib {

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ import Launcher from './lib/launcher/launcher'
  * 
  * **Recommandations:** 
  * - To get all the capacities of this Node.js library, you must set up your
- * [EML AdminTool `v2.0.0--beta.6`](https://github.com/Electron-Minecraft-Launcher/EML-AdminTool-v2) website!
+ * [EML AdminTool `v2.0.0--beta.7`](https://github.com/Electron-Minecraft-Launcher/EML-AdminTool-v2) website!
  * - If you don't want to use the EML AdminTool, you should rather use the
  * [Minecraft Launcher Core](https://npmjs.com/package/minecraft-launcher-core) library.
  *
@@ -35,7 +35,7 @@ import Launcher from './lib/launcher/launcher'
  *
  * ---
  *
- * @version 2.0.0-beta.6
+ * @version 2.0.0-7
  * @license MIT — See the `LICENSE` file for more information
  * @copyright Copyright (c) 2024, GoldFrite
  */

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import MicrosoftAuth from './lib/auth/microsoft'

--- a/lib/auth/azuriom.ts
+++ b/lib/auth/azuriom.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { Account } from '../../types/account'
@@ -10,7 +10,7 @@ import { EMLLibError, ErrorType } from '../../types/errors'
  * Authenticate a user with [Azuriom](https://azuriom.com/).
  */
 export default class AzAuth {
-  private url: string
+  private readonly url: string
 
   /**
    * @param url The URL of your Azuriom website.

--- a/lib/auth/crack.ts
+++ b/lib/auth/crack.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { Account } from '../../types/account'

--- a/lib/auth/microsoft.ts
+++ b/lib/auth/microsoft.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { BrowserWindow } from 'electron'
@@ -14,8 +14,8 @@ import { EMLLibError, ErrorType } from '../../types/errors'
  * **Attention!** Using this class requires Electron. Use `npm i electron` to install it.
  */
 export default class MicrosoftAuth {
-  private mainWindow: BrowserWindow
-  private clientId: string
+  private readonly mainWindow: BrowserWindow
+  private readonly clientId: string
 
   /**
    * @param mainWindow Your Electron application's main window (to create a child window for the Microsoft login).
@@ -190,8 +190,8 @@ export default class MicrosoftAuth {
   }
 
   private getUuid() {
-    var result = ''
-    for (var i = 0; i <= 4; i++) {
+    let result = ''
+    for (let i = 0; i <= 4; i++) {
       result += (Math.floor(Math.random() * 16777216) + 1048576).toString(16)
       if (i < 4) result += '-'
     }

--- a/lib/auth/microsoftgui.ts
+++ b/lib/auth/microsoftgui.ts
@@ -1,13 +1,13 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { BrowserWindow, app, session } from 'electron'
 
 export default class MicrosoftAuthGui {
-  private window: BrowserWindow
-  private clientId: string
+  private readonly window: BrowserWindow
+  private readonly clientId: string
 
   constructor(mainWindow: BrowserWindow, clientId: string) {
     this.window = new BrowserWindow({
@@ -45,7 +45,7 @@ export default class MicrosoftAuthGui {
           `https://login.live.com/oauth20_authorize.srf?client_id=${this.clientId}&response_type=code&redirect_uri=https://login.live.com/oauth20_desktop.srf&scope=XboxLive.signin%20offline_access&cobrandid=8058f65d-ce06-4c30-9559-473c9275a65d&prompt=select_account`
         )
 
-        var loading = false
+        let loading = false
 
         this.window.on('close', () => {
           if (!loading) resolve('cancel')

--- a/lib/background/background.ts
+++ b/lib/background/background.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { EMLLibError, ErrorType } from '../../types/errors'
@@ -12,7 +12,7 @@ import { IBackground } from '../../types/background'
  * **Attention!** This class only works with the EML AdminTool. Please do not use it without the AdminTool.
  */
 export default class Background {
-  private url: string
+  private readonly url: string
 
   /**
    * @param url The URL of your EML AdminTool website.

--- a/lib/bootstraps/bootstraps.ts
+++ b/lib/bootstraps/bootstraps.ts
@@ -1,13 +1,13 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import Downloader from '../utils/downloader'
 import utils from '../utils/utils'
 import EventEmitter from '../utils/events'
-import path_ from 'path'
-import { spawnSync } from 'child_process'
+import path_ from 'node:path'
+import { spawnSync } from 'node:child_process'
 import { EMLLibError, ErrorType } from '../../types/errors'
 import { IBootstraps } from '../../types/bootstraps'
 import { File } from '../../types/file'
@@ -20,7 +20,7 @@ import { DownloaderEvents } from '../../types/events'
  * @workInProgress
  */
 export default class Bootstraps extends EventEmitter<DownloaderEvents> {
-  private url: string
+  private readonly url: string
 
   /**
    * @param url The URL of your EML AdminTool website
@@ -115,7 +115,5 @@ export default class Bootstraps extends EventEmitter<DownloaderEvents> {
 
       this.runUpdate(bootstrapPath)
     }
-
-    return
   }
 }

--- a/lib/java/java.ts
+++ b/lib/java/java.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { DownloaderEvents, JavaEvents } from '../../types/events'

--- a/lib/java/java.ts
+++ b/lib/java/java.ts
@@ -7,10 +7,10 @@ import { DownloaderEvents, JavaEvents } from '../../types/events'
 import EventEmitter from '../utils/events'
 import manifests from '../utils/manifests'
 import { File } from '../../types/file'
-import path_ from 'path'
+import path_ from 'node:path'
 import Downloader from '../utils/downloader'
 import utils from '../utils/utils'
-import { spawnSync } from 'child_process'
+import { spawnSync } from 'node:child_process'
 import { EMLLibError, ErrorType } from '../../types/errors'
 import { MinecraftManifest } from '../../types/manifest'
 
@@ -21,9 +21,9 @@ import { MinecraftManifest } from '../../types/manifest'
  * the configuration.
  */
 export default class Java extends EventEmitter<DownloaderEvents & JavaEvents> {
-  private minecraftVersion: string | null
-  private serverId: string
-  private url?: string
+  private readonly minecraftVersion: string | null
+  private readonly serverId: string
+  private readonly url?: string
 
   /**
    * @param minecraftVersion The version of Minecraft you want to install Java for. Set to
@@ -51,36 +51,40 @@ export default class Java extends EventEmitter<DownloaderEvents & JavaEvents> {
    * @returns The files of the Java version.
    */
   async getFiles(manifest?: MinecraftManifest) {
-    manifest = manifest || (await manifests.getMinecraftManifest(this.minecraftVersion, this.url))
-    const jreVersion = (manifest.javaVersion?.component || 'jre-legacy') as
+    manifest = manifest ?? (await manifests.getMinecraftManifest(this.minecraftVersion, this.url))
+    const jreVersion = (manifest.javaVersion?.component ?? 'jre-legacy') as
       | 'java-runtime-alpha'
       | 'java-runtime-beta'
       | 'java-runtime-delta'
       | 'java-runtime-gamma'
       | 'java-runtime-gamma-snapshot'
       | 'jre-legacy'
-    const jreV = manifest.javaVersion?.majorVersion || '8'
+    const jreV = manifest.javaVersion?.majorVersion.toString() ?? '8'
 
-    const jreManifest = await manifests.getJavaManifest(jreVersion)
+    const jreManifest = await manifests.getJavaManifest(jreVersion, jreV)
 
     let files: File[] = []
 
     Object.entries(jreManifest.files).forEach((file: [string, any]) => {
+      const normalizedPath = this.normalizeJavaPath(file[0], jreV)
+      if (!normalizedPath) return
+
       if (file[1].type === 'directory') {
         files.push({
           name: path_.basename(file[0]),
-          path: path_.join('runtime', `jre-${jreV}`, path_.dirname(file[0]), '/'),
+          path: normalizedPath,
           url: '',
           type: 'FOLDER'
         })
       } else if (file[1].downloads) {
         files.push({
           name: path_.basename(file[0]),
-          path: path_.join('runtime', `jre-${jreV}`, path_.dirname(file[0]), '/'),
+          path: normalizedPath,
           url: file[1].downloads.raw.url,
           size: file[1].downloads.raw.size,
           sha1: file[1].downloads.raw.sha1,
-          type: 'JAVA'
+          type: 'JAVA',
+          executable: file[1].executable === true
         })
       }
     })
@@ -123,7 +127,7 @@ export default class Java extends EventEmitter<DownloaderEvents & JavaEvents> {
           .map((o) => o?.toString('utf8'))
           .join(' ')
           .match(/"(.*?)"/)
-          ?.pop() || majorVersion + '',
+          ?.pop() ?? majorVersion + '',
       arch: check.output
         .map((o) => o?.toString('utf8'))
         .join(' ')
@@ -134,4 +138,18 @@ export default class Java extends EventEmitter<DownloaderEvents & JavaEvents> {
     this.emit('java_info', res)
     return res
   }
+
+  private normalizeJavaPath(filePath: string, jreV: string) {
+    if (filePath.endsWith('.bundle')) return null
+    if (filePath.includes('.bundle/')) {
+      const homeIndex = filePath.indexOf('.bundle/Contents/Home/')
+      if (homeIndex === -1) return null
+
+      const relativePath = filePath.slice(homeIndex + '.bundle/Contents/Home/'.length)
+      return path_.join('runtime', `jre-${jreV}`, path_.dirname(relativePath), '/')
+    }
+
+    return path_.join('runtime', `jre-${jreV}`, path_.dirname(filePath), '/')
+  }
 }
+

--- a/lib/launcher/argumentsmanager.ts
+++ b/lib/launcher/argumentsmanager.ts
@@ -1,13 +1,13 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { FullConfig } from '../../types/config'
 import { MinecraftManifest } from '../../types/manifest'
 import utils from '../utils/utils'
-import path_ from 'path'
-import { ExtraFile, File, ILoader } from '../../types/file'
+import path_ from 'node:path'
+import { ExtraFile, ILoader } from '../../types/file'
 
 export default class ArgumentsManager {
   private config: FullConfig
@@ -193,6 +193,6 @@ export default class ArgumentsManager {
   }
 
   private getMainClass() {
-    return this.loaderManifest?.mainClass || this.manifest.mainClass
+    return this.loaderManifest?.mainClass ?? this.manifest.mainClass
   }
 }

--- a/lib/launcher/filesmanager.ts
+++ b/lib/launcher/filesmanager.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  * @copyright Copyright (c) 2019, Pierce Harriz, from [Minecraft Launcher Core](https://github.com/Pierce01/MinecraftLauncher-core)
  */
 
@@ -9,8 +9,8 @@ import { EMLLibError, ErrorType } from '../../types/errors'
 import { ExtraFile, File, ILoader } from '../../types/file'
 import { Artifact, MinecraftManifest, Assets } from '../../types/manifest'
 import utils from '../utils/utils'
-import path_ from 'path'
-import fs from 'fs'
+import path_ from 'node:path'
+import fs from 'node:fs'
 import AdmZip from 'adm-zip'
 import EventEmitter from '../utils/events'
 import { FilesManagerEvents } from '../../types/events'

--- a/lib/launcher/launcher.ts
+++ b/lib/launcher/launcher.ts
@@ -186,3 +186,4 @@ export default class Launcher extends EventEmitter<LauncherEvents & DownloaderEv
     minecraft.on('close', (code) => this.emit('launch_close', code || 0))
   }
 }
+

--- a/lib/launcher/launcher.ts
+++ b/lib/launcher/launcher.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { CleanerEvents, DownloaderEvents, FilesManagerEvents, JavaEvents, LauncherEvents, PatcherEvents } from '../../types/events'
@@ -8,21 +8,23 @@ import EventEmitter from '../utils/events'
 import manifests from '../utils/manifests'
 import utils from '../utils/utils'
 import { Config, FullConfig } from './../../types/config'
-import path_ from 'path'
+import path_ from 'node:path'
 import FilesManager from './filesmanager'
 import Downloader from '../utils/downloader'
 import Cleaner from '../utils/cleaner'
 import Java from '../java/java'
 import LoaderManager from './loadermanager'
 import ArgumentsManager from './argumentsmanager'
-import { spawn } from 'child_process'
+import { spawn } from 'node:child_process'
 
 /**
  * Launch Minecraft.
  * @workInProgress
  */
-export default class Launcher extends EventEmitter<LauncherEvents & DownloaderEvents & CleanerEvents & FilesManagerEvents & JavaEvents & PatcherEvents> {
-  private config: FullConfig
+export default class Launcher extends EventEmitter<
+  LauncherEvents & DownloaderEvents & CleanerEvents & FilesManagerEvents & JavaEvents & PatcherEvents
+> {
+  private readonly config: FullConfig
 
   /**
    * @param config The configuration of the Launcher.
@@ -174,16 +176,16 @@ export default class Launcher extends EventEmitter<LauncherEvents & DownloaderEv
     const args = argumentsManager.getArgs([...loaderFiles.libraries, ...librariesFiles.libraries], loader, loaderFiles.loaderManifest)
 
     const blindArgs = args.map((arg, i) => (i === args.findIndex((p) => p === '--accessToken') + 1 ? '**********' : arg))
-    this.emit('launch_debug', `Launching Minecraft with args: ${args.join(' ')}`)
+    this.emit('launch_debug', `Launching Minecraft with args: ${blindArgs.join(' ')}`)
 
-    this.run(this.config.java.absolutePath.replace('${X}', manifest.javaVersion?.majorVersion.toString() || '8'), args)
+    this.run(this.config.java.absolutePath.replace('${X}', manifest.javaVersion?.majorVersion.toString() ?? '8'), args)
   }
 
   private async run(javaPath: string, args: string[]) {
     const minecraft = spawn(javaPath, args, { cwd: this.config.root, detached: true })
     minecraft.stdout.on('data', (data: Buffer) => this.emit('launch_data', data.toString('utf8').replace(/\n$/, '')))
     minecraft.stderr.on('data', (data: Buffer) => this.emit('launch_data', data.toString('utf8').replace(/\n$/, '')))
-    minecraft.on('close', (code) => this.emit('launch_close', code || 0))
+    minecraft.on('close', (code) => this.emit('launch_close', code ?? 0))
   }
 }
 

--- a/lib/launcher/loadermanager.ts
+++ b/lib/launcher/loadermanager.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { FullConfig } from '../../types/config'
@@ -12,9 +12,9 @@ import ForgeLoader from './loaders/forgeloader'
 import Patcher from './loaders/patcher'
 
 export default class LoaderManager extends EventEmitter<FilesManagerEvents & PatcherEvents> {
-  private config: FullConfig
-  private manifest: MinecraftManifest
-  private loader: ILoader
+  private readonly config: FullConfig
+  private readonly manifest: MinecraftManifest
+  private readonly loader: ILoader
 
   constructor(config: FullConfig, manifest: MinecraftManifest, loader: ILoader) {
     super()

--- a/lib/launcher/loaders/forgeloader.ts
+++ b/lib/launcher/loaders/forgeloader.ts
@@ -1,22 +1,22 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { FullConfig } from '../../../types/config'
 import { ExtraFile, File, ILoader } from '../../../types/file'
 import { Artifact, MinecraftManifest } from '../../../types/manifest'
 import AdmZip from 'adm-zip'
-import fs from 'fs'
-import path_ from 'path'
+import fs from 'node:fs'
+import path_ from 'node:path'
 import utils from '../../utils/utils'
 import EventEmitter from '../../utils/events'
 import { FilesManagerEvents } from '../../../types/events'
 
 export default class ForgeLoader extends EventEmitter<FilesManagerEvents> {
-  private config: FullConfig
-  private manifest: MinecraftManifest
-  private loader: ILoader
+  private readonly config: FullConfig
+  private readonly manifest: MinecraftManifest
+  private readonly loader: ILoader
 
   constructor(config: FullConfig, manifest: MinecraftManifest, loader: ILoader) {
     super()
@@ -31,9 +31,9 @@ export default class ForgeLoader extends EventEmitter<FilesManagerEvents> {
    * to download; `files`: all files created by this method or that will be created (including `libraries`)
    */
   async setup() {
-    const forgePath = path_.join(this.config.root, this.loader.file!.path)
+    const forgePath = path_.join(this.config.root, this.loader.file.path)
     const minecraftPath = path_.join(this.config.root, 'versions', this.manifest.id)
-    const zip = new AdmZip(path_.join(forgePath, this.loader.file!.name))
+    const zip = new AdmZip(path_.join(forgePath, this.loader.file.name))
     const jar = new AdmZip(path_.join(minecraftPath, `${this.manifest.id}.jar`))
 
     if (!fs.existsSync(forgePath)) fs.mkdirSync(forgePath, { recursive: true })

--- a/lib/launcher/loaders/patcher.ts
+++ b/lib/launcher/loaders/patcher.ts
@@ -1,25 +1,24 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import AdmZip from 'adm-zip'
 import { FullConfig } from '../../../types/config'
-import { ILoader } from '../../../types/file'
+import { ILoader, File } from '../../../types/file'
 import { MinecraftManifest } from '../../../types/manifest'
 import utils from '../../utils/utils'
-import fs from 'fs'
-import path_ from 'path'
-import { spawn } from 'child_process'
-import { File } from '../../../types/file'
+import fs from 'node:fs'
+import path_ from 'node:path'
+import { spawn } from 'node:child_process'
 import EventEmitter from '../../utils/events'
 import { PatcherEvents } from '../../../types/events'
 
 export default class Patcher extends EventEmitter<PatcherEvents> {
-  private config: FullConfig
-  private manifest: MinecraftManifest
-  private loader: ILoader
-  private installProfile: any
+  private readonly config: FullConfig
+  private readonly manifest: MinecraftManifest
+  private readonly loader: ILoader
+  private readonly installProfile: any
 
   constructor(config: FullConfig, manifest: MinecraftManifest, loader: ILoader, installProfile: any) {
     super()

--- a/lib/maintenance/maintenance.ts
+++ b/lib/maintenance/maintenance.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { EMLLibError, ErrorType } from '../../types/errors'
@@ -12,7 +12,7 @@ import { IMaintenance } from '../../types/maintenance'
  * **Attention!** This class only works with the EML AdminTool. Please do not use it without the AdminTool.
  */
 export default class Maintenance {
-  private url: string
+  private readonly url: string
 
   /**
    * @param url The URL of your EML AdminTool website.

--- a/lib/news/news.ts
+++ b/lib/news/news.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { EMLLibError, ErrorType } from '../../types/errors'
@@ -12,7 +12,7 @@ import { INews, INewsCategory } from '../../types/news'
  * **Attention!** This class only works with the EML AdminTool. Please do not use it without the AdminTool.
  */
 export default class News {
-  private url: string
+  private readonly url: string
 
   /**
    * @param url The URL of your EML AdminTool website.

--- a/lib/serverstatus/bufferreader.ts
+++ b/lib/serverstatus/bufferreader.ts
@@ -1,11 +1,11 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  * @copyright Copyright (c) 2020, Nick Krecklow
  */
 
 export default class BufferReader {
-  private buffer: Buffer
+  private readonly buffer: Buffer
   private offset: number
 
   constructor(buffer: Buffer) {

--- a/lib/serverstatus/bufferwriter.ts
+++ b/lib/serverstatus/bufferwriter.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  * @copyright Copyright (c) 2020, Nick Krecklow
  */
 

--- a/lib/serverstatus/serverstatus.ts
+++ b/lib/serverstatus/serverstatus.ts
@@ -1,10 +1,10 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  * @copyright Copyright (c) 2020, Nick Krecklow
  */
 
-import * as net from 'net'
+import * as net from 'node:net'
 import type { ServerStatus as ServerStatus_ } from '../../types/status'
 import { EMLLibError, ErrorType } from '../../types/errors'
 import BufferWriter from './bufferwriter'
@@ -14,11 +14,11 @@ import BufferReader from './bufferreader'
  * Get the status of a Minecraft server.
  */
 export default class ServerStatus {
-  private ip: string
-  private port: number
-  private protocol: 'modern' | '1.6' | '1.4-1.5' | 'Beta1.8-1.3'
-  private pvn: number
-  private timeout: number
+  private readonly ip: string
+  private readonly port: number
+  private readonly protocol: 'modern' | '1.6' | '1.4-1.5' | 'Beta1.8-1.3'
+  private readonly pvn: number
+  private readonly timeout: number
 
   /**
    * **Attention!** This class may not work for some Minecraft servers (Minecraft 1.4 and below, or 

--- a/lib/utils/cleaner.ts
+++ b/lib/utils/cleaner.ts
@@ -1,16 +1,16 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import EventEmitter from './events'
-import path_ from 'path'
-import fs from 'fs'
+import path_ from 'node:path'
+import fs from 'node:fs'
 import { CleanerEvents } from '../../types/events'
 import { File } from '../../types/file'
 
 export default class Cleaner extends EventEmitter<CleanerEvents> {
-  private dest: string = ''
+  private readonly dest: string = ''
   private browsed: { name: string; path: string }[] = []
 
   /**

--- a/lib/utils/downloader.ts
+++ b/lib/utils/downloader.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { File } from '../../types/file'

--- a/lib/utils/events.ts
+++ b/lib/utils/events.ts
@@ -3,10 +3,10 @@
  * @copyright Copyright (c) 2024, GoldFrite
  */
 
-import { EventEmitter as EM } from 'events'
+import { EventEmitter as EM } from 'node:events'
 
 export default class EventEmitter<T extends EventMap<T> = DefaultEventMap> {
-  private emitter: EM<T>
+  private readonly emitter: EM<T>
 
   constructor() {
     this.emitter = new EM<T>()

--- a/lib/utils/events.ts
+++ b/lib/utils/events.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { EventEmitter as EM } from 'node:events'

--- a/lib/utils/manifests.ts
+++ b/lib/utils/manifests.ts
@@ -83,9 +83,10 @@ class Manifests {
       | 'java-runtime-delta'
       | 'java-runtime-gamma'
       | 'java-runtime-gamma-snapshot'
-      | 'jre-legacy'
+      | 'jre-legacy',
+    jreV: string
   ): Promise<{ files: any }> {
-    const url = await this.getJavaManifestUrl(javaVersion)
+    const url = await this.getJavaManifestUrl(javaVersion, jreV)
 
     const res = await fetch(url)
       .then((res) => res.json())
@@ -99,6 +100,7 @@ class Manifests {
   /**
    * Get the manifest URL of the Java version.
    * @param javaVersion The version of Java you want to get the manifest for.
+   * @param jreV The major version of Java Runtime Environment (JRE) you want to get the manifest for (fallback if `javaVersion` is not found).
    * @returns The manifest URL of the Java version.
    */
   async getJavaManifestUrl(
@@ -108,7 +110,8 @@ class Manifests {
       | 'java-runtime-delta'
       | 'java-runtime-gamma'
       | 'java-runtime-gamma-snapshot'
-      | 'jre-legacy'
+      | 'jre-legacy',
+    jreV: string
   ) {
     const archMapping = {
       win32: { x64: 'windows-x64', ia32: 'windows-x86', arm64: 'windows-arm64' },
@@ -136,17 +139,21 @@ class Manifests {
         throw new EMLLibError(ErrorType.FETCH_ERROR, `Failed to fetch Java manifest: ${err.message}`)
       })
 
-    if (
-      !res[archMapping[platform][arch]] ||
-      !res[archMapping[platform][arch]][javaVersion] ||
-      !res[archMapping[platform][arch]][javaVersion][0] ||
-      !res[archMapping[platform][arch]][javaVersion][0].manifest
-    ) {
-      throw new EMLLibError(ErrorType.JAVA_ERROR, `Java version ${javaVersion} not found in manifest`)
+    if (res[archMapping[platform][arch]][javaVersion][0]?.manifest) {
+      return res[archMapping[platform][arch]][javaVersion][0].manifest.url as string
     }
 
-    return res[archMapping[platform][arch]][javaVersion][0].manifest.url as string
+    const fallbackJavaVersion = Object.keys(res[archMapping[platform][arch]]).find(
+      (version) => res[archMapping[platform][arch]][version][0]?.version.name.split('.')[0] === jreV
+    )
+
+    if (fallbackJavaVersion) {
+      return res[archMapping[platform][arch]][fallbackJavaVersion][0].manifest.url as string
+    }
+
+    throw new EMLLibError(ErrorType.JAVA_ERROR, `Java version ${javaVersion} not found in manifest`)
   }
 }
 
 export default new Manifests()
+

--- a/lib/utils/manifests.ts
+++ b/lib/utils/manifests.ts
@@ -1,3 +1,8 @@
+/**
+ * @license MIT
+ * @copyright Copyright (c) 2025, GoldFrite
+ */
+
 import { MinecraftManifest } from './../../types/manifest.d'
 import { EMLLibError, ErrorType } from '../../types/errors'
 import { JAVA_RUNTIME_URL, MINECRAFT_MANIFEST_URL } from './consts'

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -1,13 +1,13 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 import { EMLLibError, ErrorType } from '../../types/errors'
-import path_ from 'path'
-import fs from 'fs'
-import crypto from 'crypto'
-import os from 'os'
+import path_ from 'node:path'
+import fs from 'node:fs'
+import crypto from 'node:crypto'
+import os from 'node:os'
 import { ExtraFile } from '../../types/file'
 
 class Utils {
@@ -184,8 +184,6 @@ class Utils {
    */
   isNewer(ref: ExtraFile, check: ExtraFile) {
     if (ref.sha1 === check.sha1) return null // Same file, so same version
-    // if (ref.extra === 'MINECRAFT' && check.extra !== 'MINECRAFT') return false // Minecraft always wins
-    // if (ref.extra !== 'MINECRAFT' && check.extra === 'MINECRAFT') return true // Minecraft always wins
 
     if (ref.name.split('-').pop() !== check.name.split('-').pop()) return false // Different libraries, so keep both of them (always return false)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eml-lib",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eml-lib",
-      "version": "2.0.0-beta.6",
+      "version": "2.0.0-beta.7",
       "license": "MIT",
       "dependencies": {
         "@electron/remote": "^2.1.2",
@@ -78,9 +78,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
-      "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
     },
@@ -185,23 +185,23 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
-      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "version": "24.9.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.2.tgz",
+      "integrity": "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/node-fetch": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.12.tgz",
-      "integrity": "sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==",
+      "version": "2.6.13",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
+      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "form-data": "^4.0.0"
+        "form-data": "^4.0.4"
       }
     },
     "node_modules/@types/responselike": {
@@ -370,9 +370,9 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -519,9 +519,9 @@
       }
     },
     "node_modules/electron/node_modules/@types/node": {
-      "version": "20.19.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
-      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
+      "version": "20.19.24",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.24.tgz",
+      "integrity": "sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -763,9 +763,9 @@
       }
     },
     "node_modules/global-agent/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
       "optional": true,
       "bin": {
@@ -818,7 +818,7 @@
         "cacheable-lookup": "^5.0.3",
         "cacheable-request": "^7.0.2",
         "decompress-response": "^6.0.0",
-        "http2-wrapper": "^1.0.0-beta.6.2",
+        "http2-wrapper": "^1.0.0-beta.5.2",
         "lowercase-keys": "^2.0.0",
         "p-cancelable": "^2.0.0",
         "responselike": "^2.0.0"
@@ -1282,9 +1282,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1296,9 +1296,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eml-lib",
-  "version": "2.0.0-beta.6",
+  "version": "2.0.0-beta.7",
   "description": "Create your Electron Minecraft Launcher easily!",
   "author": "GoldFrite",
   "license": "MIT",

--- a/test/test.ts
+++ b/test/test.ts
@@ -2,9 +2,8 @@ import EMLLib from '../index'
 
 
 async function main() {
-  new EMLLib.MicrosoftAuth()
   const launcher = new EMLLib.Launcher({
-    url: 'http://localhost:5173',
+    url: 'http://localhost:8080',
     serverId: 'goldfrite',
     account: new EMLLib.CrackAuth().auth('GoldFrite'),
     cleaning: {
@@ -20,7 +19,7 @@ async function main() {
     launcher.on('download_error', (error) => console.error(error.type, `=> Error downloading ${error.filename}: ${error.message}`))
     launcher.on('download_end', (info) => console.log(`Downloaded ${info.downloaded.amount} files.`))
 
-    launcher.on('launch_install_loader', (loader) => console.log(`\nInstalling loader ${loader.loader} ${loader.loader_version}...`))
+    launcher.on('launch_install_loader', (loader) => console.log(`\nInstalling loader ${loader.type} ${loader.loaderVersion}...`))
 
     launcher.on('launch_extract_natives', () => console.log('\nExtracting natives...'))
     launcher.on('extract_progress', (progress) => console.log(`Extracted ${progress.filename}.`))
@@ -43,7 +42,7 @@ async function main() {
     launcher.on('clean_end', (info) => console.log(`Cleaned ${info.amount} files.`))
 
     launcher.on('launch_launch', (info) =>
-      console.log(`\nLaunching Minecraft ${info.version} (${info.loader}${info.loaderVersion ? ` ${info.loaderVersion}` : ''})...`)
+      console.log(`\nLaunching Minecraft ${info.version} (${info.type}${info.loaderVersion ? ` ${info.loaderVersion}` : ''})...`)
     )
     launcher.on('launch_data', (message) => console.log(message))
     launcher.on('launch_close', (code) => console.log(`Closed with code ${code}.`))
@@ -58,3 +57,4 @@ async function main() {
 }
 
 main()
+

--- a/types/errors.ts
+++ b/types/errors.ts
@@ -1,6 +1,6 @@
 /**
  * @license MIT
- * @copyright Copyright (c) 2024, GoldFrite
+ * @copyright Copyright (c) 2025, GoldFrite
  */
 
 /**

--- a/types/file.d.ts
+++ b/types/file.d.ts
@@ -37,6 +37,7 @@ export interface File {
    * `'OTHER'`: Other files
    */
   type: 'JAVA' | 'ASSET' | 'LIBRARY' | 'NATIVE' | 'MOD' | 'CONFIG' | 'BOOTSTRAP' | 'BACKGROUND' | 'FOLDER' | 'IMAGE' | 'OTHER'
+  executable?: boolean
 }
 
 export interface ILoader {


### PR DESCRIPTION
Resolved an issue where Java was not installed correctly on macOS by improving path normalization and manifest selection logic. Added executable flag to File type and ensured proper file permissions for Java executables. Updated documentation, changelog, and test cases for 2.0.0-beta.7 release, and bumped dependencies and version numbers.