### PR TITLE
Release v2.0.0-beta.10 and fix type exports

### DIFF
--- a/.github/changelogs/v2.0.0-beta.10.md
+++ b/.github/changelogs/v2.0.0-beta.10.md
@@ -1,0 +1,9 @@
+## Change Logs
+
+### Bug fixes
+
+- Fixed types. 
+
+### Known issues
+
+- ETA while downloading is not accurate.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [<img src="https://img.shields.io/badge/Discord-EML-5561e6?&style=for-the-badge">](https://discord.gg/YVB4k6HzAY)
 [<img src="https://img.shields.io/badge/platforms-Windows%2C%20macOS%2C%20Linux-0077DA?style=for-the-badge&color=0077DA">](#platforms)
-[<img src="https://img.shields.io/badge/version-2.0.0--beta.9-orangered?style=for-the-badge&color=orangered">](package.json)
+[<img src="https://img.shields.io/badge/version-2.0.0--beta.10-orangered?style=for-the-badge&color=orangered">](package.json)
 
 ---
 

--- a/index.ts
+++ b/index.ts
@@ -14,17 +14,17 @@ import ServerStatus from './lib/serverstatus/serverstatus'
 import Java from './lib/java/java'
 import Launcher from './lib/launcher/launcher'
 
-export * from './types/account'
-export * from './types/background'
-export * from './types/bootstraps'
-export * from './types/config'
-export * from './types/errors'
-export * from './types/events'
-export * from './types/file'
-export * from './types/maintenance'
-export * from './types/manifest'
-export * from './types/news'
-export * from './types/status'
+export type * from './types/account'
+export type * from './types/background'
+export type * from './types/bootstraps'
+export type * from './types/config'
+export type * from './types/errors'
+export type * from './types/events'
+export type * from './types/file'
+export type * from './types/maintenance'
+export type * from './types/manifest'
+export type * from './types/news'
+export type * from './types/status'
 
 /**
  * Authenticate a user with Microsoft.
@@ -118,7 +118,7 @@ export { Launcher }
  *
  * ---
  *
- * @version 2.0.0-beta.9
+ * @version 2.0.0-beta.10
  * @license MIT — See the `LICENSE` file for more information
  * @copyright Copyright (c) 2025, GoldFrite
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eml-lib",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.0-beta.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eml-lib",
-      "version": "2.0.0-beta.9",
+      "version": "2.0.0-beta.10",
       "license": "MIT",
       "dependencies": {
         "@electron/remote": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eml-lib",
-  "version": "2.0.0-beta.9",
+  "version": "2.0.0-beta.10",
   "description": "Create your Electron Minecraft Launcher easily!",
   "author": "GoldFrite",
   "license": "MIT",
@@ -8,7 +8,7 @@
   "types": "index.d.ts",
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && electron ./test/index.js"
+    "test": "ts-node test/test.ts"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump version to 2.0.0-beta.10 across documentation and package files. Update type exports in index.ts to use 'export type *' for improved type safety. Add changelog for this release and update test script in package.json.