### PR TITLE
Bump to v2.0.0-beta.15 and fix ServerStatus error handling

### DIFF
--- a/.github/changelogs/v2.0.0-beta.15.md
+++ b/.github/changelogs/v2.0.0-beta.15.md
@@ -1,0 +1,5 @@
+## Change Logs
+
+### Bug fixes
+
+- Fixed an issue where ServerStatus threw an unhandled exception when pinging an offline server.

--- a/index.ts
+++ b/index.ts
@@ -118,7 +118,7 @@ export { Launcher }
  *
  * ---
  *
- * @version 2.0.0-beta.14
+ * @version 2.0.0-beta.15
  * @license MIT — See the `LICENSE` file for more information
  * @copyright Copyright (c) 2025, GoldFrite
  */

--- a/lib/serverstatus/bufferreader.ts
+++ b/lib/serverstatus/bufferreader.ts
@@ -40,7 +40,7 @@ export default class BufferReader {
 
   readStringUTF16BE() {
     const length = this.readVarInt() * 2
-    const val = this.buffer.subarray(this.offset + 1, this.offset + length)
+    const val = Buffer.from(this.buffer.subarray(this.offset + 1, this.offset + length))
 
     for (let i = 0; i < val.length; i += 2) {
       const temp = val[i]

--- a/lib/serverstatus/serverstatus.ts
+++ b/lib/serverstatus/serverstatus.ts
@@ -21,7 +21,7 @@ export default class ServerStatus {
   private readonly timeout: number
 
   /**
-   * **Attention!** This class may not work for some Minecraft servers (Minecraft 1.4 and below, or 
+   * **Attention!** This class may not work for some Minecraft servers (Minecraft 1.4 and below, or
    * servers with a specific configuration). If you encounter any problems, please [open an
    * issue](https://github.com/Electron-Minecraft-Launcher/EML-Lib-v2/issues).
    * @param ip Your Minecraft Server's IP or Host (eg. `'172.65.236.36'` or `'mc.hypixel.net'`).
@@ -31,10 +31,10 @@ export default class ServerStatus {
    * 12w32a/1.4 to 1.5.2).
    * @param pvn [Optional: default is `-1`] The Minecraft protocol version (eg. `754` for 1.16.4).
    * This parameter is optional, but it is recommended to use it for better compatibility. You can
-   * find the protocol version of your Minecraft version [here](https://wiki.vg/Protocol_version_numbers).
+   * find the protocol version of your Minecraft version [here](https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Protocol_version_numbers).
    * @param timeout [Optional: default is `5`] The timeout in seconds.
    */
-  constructor(ip: string, port: number = 25565, protocol: 'modern' | '1.6' | '1.4-1.5', pvn: number, timeout: number = 5) {
+  constructor(ip: string, port: number = 25565, protocol: 'modern' | '1.6' | '1.4-1.5' = 'modern', pvn: number = -1, timeout: number = 5) {
     this.ip = ip
     this.port = port
     this.protocol = protocol
@@ -54,7 +54,7 @@ export default class ServerStatus {
       socket.setNoDelay(true)
 
       const timeout = setTimeout(() => {
-        throw new EMLLibError(ErrorType.NET_ERROR, 'Connection timed out')
+        reject(new EMLLibError(ErrorType.NET_ERROR, 'Connection timed out'))
       }, this.timeout * 1000)
 
       socket.on('connect', () => {
@@ -169,4 +169,3 @@ export default class ServerStatus {
     })
   }
 }
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eml-lib",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eml-lib",
-      "version": "2.0.0-beta.14",
+      "version": "2.0.0-beta.15",
       "license": "MIT",
       "dependencies": {
         "@electron/remote": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eml-lib",
-  "version": "2.0.0-beta.14",
+  "version": "2.0.0-beta.15",
   "description": "Create your Electron Minecraft Launcher easily!",
   "author": "GoldFrite",
   "license": "MIT",


### PR DESCRIPTION
Updated version to 2.0.0-beta.15. Fixed ServerStatus to properly reject with an error on connection timeout instead of throwing, preventing unhandled exceptions when pinging offline servers. Improved BufferReader string handling and updated documentation links and constructor defaults.