### PR TITLE
Bump version to 2.0.0-beta.17 and emit 'download_end' event

### DIFF
--- a/.github/changelogs/v2.0.0-beta.17.md
+++ b/.github/changelogs/v2.0.0-beta.17.md
@@ -1,0 +1,5 @@
+## Change Logs
+
+### Bug fixes and improvements
+
+* Added missing event emission for 'download_end' in Bootstraps when an update is downloaded.

--- a/index.ts
+++ b/index.ts
@@ -118,7 +118,7 @@ export { Launcher }
  *
  * ---
  *
- * @version 2.0.0-beta.16
+ * @version 2.0.0-beta.17
  * @license MIT — See the `LICENSE` file for more information
  * @copyright Copyright (c) 2025, GoldFrite
  */

--- a/lib/bootstraps/bootstraps.ts
+++ b/lib/bootstraps/bootstraps.ts
@@ -122,6 +122,10 @@ export default class Bootstraps extends EventEmitter<DownloaderEvents & Bootstra
       })
     })
 
+    this.autoUpdater.on('update-downloaded', () => {
+      this.emit('download_end', { downloaded: { amount: 1, size: -1 } })
+    })
+
     return this.autoUpdater
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eml-lib",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eml-lib",
-      "version": "2.0.0-beta.16",
+      "version": "2.0.0-beta.17",
       "license": "MIT",
       "dependencies": {
         "@electron/remote": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eml-lib",
-  "version": "2.0.0-beta.16",
+  "version": "2.0.0-beta.17",
   "description": "Create your Electron Minecraft Launcher easily!",
   "author": "GoldFrite",
   "license": "MIT",


### PR DESCRIPTION
Updated version to 2.0.0-beta.17. Added missing 'download_end' event emission in Bootstraps when an update is downloaded to improve event handling.