### PR TITLE
Use skin-based avatars; bump to v2.3.1

### DIFF
--- a/.github/changelogs/v2.3.1.md
+++ b/.github/changelogs/v2.3.1.md
@@ -1,0 +1,5 @@
+## Changelog
+
+### Bug fixes and improvements
+
+- Avatar from Microsoft accounts are now generated from the skin instead of using Minotar.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [<img src="https://img.shields.io/badge/Discord-EML-5561e6?&style=for-the-badge">](https://emlproject.com/discord/github)
 [<img src="https://img.shields.io/badge/platforms-Windows%2C%20macOS%2C%20Linux-0077DA?style=for-the-badge&color=0077DA">](#platforms)
-[<img src="https://img.shields.io/badge/version-2.3.0-orangered?style=for-the-badge&color=orangered">](package.json)
+[<img src="https://img.shields.io/badge/version-2.3.1-orangered?style=for-the-badge&color=orangered">](package.json)
 
 <p>
 <center>

--- a/index.ts
+++ b/index.ts
@@ -162,7 +162,7 @@ export { Launcher }
  *
  * ---
  *
- * @version 2.3.0
+ * @version 2.3.1
  * @license MIT — See the `LICENSE` file for more information
  * @copyright Copyright (c) 2026, GoldFrite and contributors
  */

--- a/lib/skin/skin.ts
+++ b/lib/skin/skin.ts
@@ -222,7 +222,7 @@ export default class Skin {
 
       this.avatar = {
         id: this.account.uuid,
-        url: `https://minotar.com/avatar/${this.account.name}/256.png`
+        url: await this.getAvatarFromSkin(this.skins.find((skin) => skin.state === 'active')?.url ?? this.skins[0]?.url ?? null)
       }
     } catch (err: any) {
       if (err instanceof EMLLibError) throw err
@@ -622,8 +622,8 @@ export default class Skin {
   }
 
   // util
-  private async getAvatarFromSkin(skinUrl: string, size: number = 256) {
-    if (typeof window === 'undefined' || typeof document === 'undefined') {
+  private async getAvatarFromSkin(skinUrl: string | null, size: number = 256) {
+    if (typeof window === 'undefined' || typeof document === 'undefined' || !skinUrl) {
       return null
     }
 
@@ -654,6 +654,7 @@ export default class Skin {
     }
   }
 }
+
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eml-lib",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eml-lib",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eml-lib",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Create your Electron Minecraft Launcher easily!",
   "author": "GoldFrite",
   "license": "MIT",


### PR DESCRIPTION
Replace Minotar-based avatar URLs with avatars generated from the active skin (falls back to first skin). Update getAvatarFromSkin to accept null and to return null in non-browser environments or when no skin URL is available. Add a changelog for v2.3.1 and update version references in README and index.ts and package.json.