### PR TITLE
Bump to v2.3.2; use atob for skin

### DIFF
--- a/.github/changelogs/v2.3.2.md
+++ b/.github/changelogs/v2.3.2.md
@@ -1,0 +1,5 @@
+## Changelog
+
+### Bug fixes and improvements
+
+- Replace `Buffer.from` with `atob` in _Skin_ class to decode base64 textures, which is more compatible with browser environments.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [<img src="https://img.shields.io/badge/Discord-EML-5561e6?&style=for-the-badge">](https://emlproject.com/discord/github)
 [<img src="https://img.shields.io/badge/platforms-Windows%2C%20macOS%2C%20Linux-0077DA?style=for-the-badge&color=0077DA">](#platforms)
-[<img src="https://img.shields.io/badge/version-2.3.1-orangered?style=for-the-badge&color=orangered">](package.json)
+[<img src="https://img.shields.io/badge/version-2.3.2-orangered?style=for-the-badge&color=orangered">](package.json)
 
 <p>
 <center>

--- a/index.ts
+++ b/index.ts
@@ -162,7 +162,7 @@ export { Launcher }
  *
  * ---
  *
- * @version 2.3.1
+ * @version 2.3.2
  * @license MIT — See the `LICENSE` file for more information
  * @copyright Copyright (c) 2026, GoldFrite and contributors
  */

--- a/lib/skin/skin.ts
+++ b/lib/skin/skin.ts
@@ -242,7 +242,7 @@ export default class Skin {
       const textures = data.properties?.find((prop: any) => prop.name === 'textures')?.value
 
       if (textures) {
-        const decoded = JSON.parse(Buffer.from(textures, 'base64').toString('utf-8'))
+        const decoded = JSON.parse(atob(textures))
 
         if (decoded.textures?.SKIN) {
           this.skins = [
@@ -654,8 +654,5 @@ export default class Skin {
     }
   }
 }
-
-
-
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eml-lib",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eml-lib",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eml-lib",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Create your Electron Minecraft Launcher easily!",
   "author": "GoldFrite",
   "license": "MIT",


### PR DESCRIPTION
Replace Buffer.from with atob in the Skin class to decode base64 textures for better browser compatibility. Update project version to 2.3.2 in package.json, README badge, and index.ts, and add a changelog entry documenting the fix.