### PR TITLE
Allow Skin to fetch avatars in renderer & main

### DIFF
--- a/.github/changelogs/v2.3.3.md
+++ b/.github/changelogs/v2.3.3.md
@@ -1,0 +1,5 @@
+## Changelog
+
+### Changes
+
+- You can now fetch the avatar of an authenticated account using the _Skin_ class from both the main and renderer processes.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [<img src="https://img.shields.io/badge/Discord-EML-5561e6?&style=for-the-badge">](https://emlproject.com/discord/github)
 [<img src="https://img.shields.io/badge/platforms-Windows%2C%20macOS%2C%20Linux-0077DA?style=for-the-badge&color=0077DA">](#platforms)
-[<img src="https://img.shields.io/badge/version-2.3.2-orangered?style=for-the-badge&color=orangered">](package.json)
+[<img src="https://img.shields.io/badge/version-2.3.3-orangered?style=for-the-badge&color=orangered">](package.json)
 
 <p>
 <center>

--- a/index.ts
+++ b/index.ts
@@ -162,7 +162,7 @@ export { Launcher }
  *
  * ---
  *
- * @version 2.3.2
+ * @version 2.3.3
  * @license MIT — See the `LICENSE` file for more information
  * @copyright Copyright (c) 2026, GoldFrite and contributors
  */

--- a/lib/skin/skin.ts
+++ b/lib/skin/skin.ts
@@ -623,9 +623,11 @@ export default class Skin {
 
   // util
   private async getAvatarFromSkin(skinUrl: string | null, size: number = 256) {
-    if (typeof window === 'undefined' || typeof document === 'undefined' || !skinUrl) {
+    if (!skinUrl) {
       return null
     }
+
+    const inRenderer = typeof window !== 'undefined' && typeof document !== 'undefined'
 
     try {
       const req = await fetch(skinUrl)
@@ -635,19 +637,54 @@ export default class Skin {
         throw new EMLLibError(ErrorType.FETCH_ERROR, `Error while fetching avatar from skin: HTTP ${req.status} ${errorText}`)
       }
 
-      const blob = await req.blob()
-      const img = await createImageBitmap(blob)
+      if (inRenderer) {
+        const blob = await req.blob()
+        const img = await createImageBitmap(blob)
 
-      const canvas = document.createElement('canvas')
-      canvas.width = size
-      canvas.height = size
+        const canvas = document.createElement('canvas')
+        canvas.width = size
+        canvas.height = size
 
-      const ctx = canvas.getContext('2d')!
-      ctx.imageSmoothingEnabled = false
-      ctx.drawImage(img, 8, 8, 8, 8, 0, 0, size, size)
-      ctx.drawImage(img, 40, 8, 8, 8, 0, 0, size, size)
+        const ctx = canvas.getContext('2d')!
+        ctx.imageSmoothingEnabled = false
+        ctx.drawImage(img, 8, 8, 8, 8, 0, 0, size, size)
+        ctx.drawImage(img, 40, 8, 8, 8, 0, 0, size, size)
 
-      return canvas.toDataURL('image/png')
+        return canvas.toDataURL('image/png')
+      } else {
+        const { PNG } = await import('pngjs')
+
+        const arrayBuffer = await req.arrayBuffer()
+        const src = PNG.sync.read(Buffer.from(arrayBuffer))
+
+        const out = new PNG({ width: size, height: size, filterType: -1 })
+        for (let y = 0; y < size; y++) {
+          for (let x = 0; x < size; x++) {
+            const srcX = Math.floor((x / size) * 8)
+            const srcY = Math.floor((y / size) * 8)
+            const dstIdx = (y * size + x) * 4
+
+            const faceIdx = ((srcY + 8) * src.width + (srcX + 8)) * 4
+            out.data[dstIdx + 0] = src.data[faceIdx + 0]
+            out.data[dstIdx + 1] = src.data[faceIdx + 1]
+            out.data[dstIdx + 2] = src.data[faceIdx + 2]
+            out.data[dstIdx + 3] = src.data[faceIdx + 3]
+
+            const hatIdx = ((srcY + 8) * src.width + (srcX + 40)) * 4
+            const hatAlpha = src.data[hatIdx + 3]
+            if (hatAlpha > 0) {
+              const a = hatAlpha / 255
+              out.data[dstIdx + 0] = Math.round(src.data[hatIdx + 0] * a + out.data[dstIdx + 0] * (1 - a))
+              out.data[dstIdx + 1] = Math.round(src.data[hatIdx + 1] * a + out.data[dstIdx + 1] * (1 - a))
+              out.data[dstIdx + 2] = Math.round(src.data[hatIdx + 2] * a + out.data[dstIdx + 2] * (1 - a))
+              out.data[dstIdx + 3] = 255
+            }
+          }
+        }
+
+        const buffer = PNG.sync.write(out)
+        return `data:image/png;base64,${buffer.toString('base64')}`
+      }
     } catch (err: any) {
       if (err instanceof EMLLibError) throw err
       throw new EMLLibError(ErrorType.FETCH_ERROR, `Error while fetching avatar from skin: ${err.message ?? err}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,21 @@
 {
   "name": "eml-lib",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eml-lib",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "license": "MIT",
       "dependencies": {
+        "pngjs": "^7.0.0",
         "tslib": "^2.8.1",
         "yauzl": "^3.2.1",
         "yazl": "^3.3.1"
       },
       "devDependencies": {
+        "@types/pngjs": "^6.0.5",
         "@types/yauzl": "^2.10.3",
         "@types/yazl": "^3.3.1",
         "prettier": "^3.8.3",
@@ -562,6 +564,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/pngjs": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-6.0.5.tgz",
+      "integrity": "sha512-0k5eKfrA83JOZPppLtS2C7OUtyNAl2wKNxfyYl9Q5g9lPkgBl/9hNyAu6HuEH2J4XmIv2znEpkDd0SaZVxW6iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/responselike": {
@@ -1407,6 +1419,15 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
+      }
     },
     "node_modules/prettier": {
       "version": "3.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eml-lib",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Create your Electron Minecraft Launcher easily!",
   "author": "GoldFrite",
   "license": "MIT",
@@ -36,11 +36,13 @@
   },
   "homepage": "https://github.com/Electron-Minecraft-Launcher/EML-Lib#readme",
   "dependencies": {
+    "pngjs": "^7.0.0",
     "tslib": "^2.8.1",
     "yauzl": "^3.2.1",
     "yazl": "^3.3.1"
   },
   "devDependencies": {
+    "@types/pngjs": "^6.0.5",
     "@types/yauzl": "^2.10.3",
     "@types/yazl": "^3.3.1",
     "prettier": "^3.8.3",

--- a/test/test.ts
+++ b/test/test.ts
@@ -19,10 +19,14 @@ async function mainWithElectron() {
     const msAuth = new EMLLib.MicrosoftAuth(mainWindow)
     try {
       const account = await msAuth.auth()
+      const skin = new EMLLib.Skin(account)
+
       console.log('Authenticated account:', account)
+      console.log('Avatar is:', await skin.getAvatar())
     } catch (err) {
       console.error('Authentication error:', err)
     }
+
 
     app.quit()
   })


### PR DESCRIPTION
Enable Skin.getAvatarFromSkin to work in both renderer and main processes by branching on environment: use canvas/createImageBitmap in the renderer and pngjs to decode and composite PNG data in Node. Bump package version to 2.3.3, add pngjs (and @types/pngjs dev type) as dependencies, update README version badge, add changelog v2.3.3, and update test to demonstrate fetching an authenticated account avatar. Also include error handling and preserve existing behavior.