### PR TITLE
Bump v2.3.4; fix Cleaner ignored paths

### DIFF
--- a/.github/changelogs/v2.3.4.md
+++ b/.github/changelogs/v2.3.4.md
@@ -1,0 +1,5 @@
+## Changelog
+
+### Bug fixes and improvements
+
+- Fix cleaner that may clean files that were in the `ignored` list (thanks to @Wistaro).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [<img src="https://img.shields.io/badge/Discord-EML-5561e6?&style=for-the-badge">](https://emlproject.com/discord/github)
 [<img src="https://img.shields.io/badge/platforms-Windows%2C%20macOS%2C%20Linux-0077DA?style=for-the-badge&color=0077DA">](#platforms)
-[<img src="https://img.shields.io/badge/version-2.3.3-orangered?style=for-the-badge&color=orangered">](package.json)
+[<img src="https://img.shields.io/badge/version-2.3.4-orangered?style=for-the-badge&color=orangered">](package.json)
 
 <p>
 <center>

--- a/index.ts
+++ b/index.ts
@@ -162,7 +162,7 @@ export { Launcher }
  *
  * ---
  *
- * @version 2.3.3
+ * @version 2.3.4
  * @license MIT — See the `LICENSE` file for more information
  * @copyright Copyright (c) 2026, GoldFrite and contributors
  */

--- a/lib/utils/cleaner.ts
+++ b/lib/utils/cleaner.ts
@@ -41,7 +41,7 @@ export default class Cleaner extends EventEmitter<CleanerEvents> {
     for (const file of browsed) {
       const fullPath = path_.resolve('/', file.path, file.name).replace(/\\/g, '/')
       const isFileValid = validFilesSet.has(fullPath)
-      const isIgnored = ignoredPaths.some((ig) => fullPath.startsWith(ig))
+      const isIgnored = ignoredPaths.some((ig) => fullPath.startsWith(ig.replace(/\\/g, '/')) || fullPath.startsWith(ig))
       if (!isFileValid && !isIgnored) {
         deletePromises.push(
           fs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eml-lib",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eml-lib",
-      "version": "2.3.3",
+      "version": "2.3.4",
       "license": "MIT",
       "dependencies": {
         "pngjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eml-lib",
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "Create your Electron Minecraft Launcher easily!",
   "author": "GoldFrite",
   "license": "MIT",

--- a/test/test.ts
+++ b/test/test.ts
@@ -36,9 +36,17 @@ async function main() {
   const launcher = new EMLLib.Launcher({
     root: 'goldfrite',
     account: new EMLLib.CrackAuth().auth('Goldfrite'),
-    memory: {
-      min: 2048,
-      max: 4096
+    storage: 'isolated',
+    profile: {
+      slug: 'drayon-paradise',
+      minecraft: {
+        version: '1.21.1',
+        loader: {
+          loader: 'neoforge',
+          version: '21.1.220'
+        },
+        // modpackUrl: 'https://wistaro.fr/projets/drayonparadise/distribution.json' /*Temps for tests*/
+      }
     }
   })
 
@@ -93,5 +101,6 @@ async function featureTest() {
   console.log(account)
 }
 
-mainWithElectron()
+main()
+
 


### PR DESCRIPTION
Release v2.3.4: fix a bug in Cleaner where files in the ignored list could be deleted by normalizing backslashes when matching ignored paths (thanks @Wistaro). Update version strings in index, package.json and package-lock.json, add changelog entry, and adjust tests to new launcher config (storage/profile/minecraft) and call main() instead of mainWithElectron().