### PR TITLE
Bump to v2.3.5 and export skin types

### DIFF
--- a/.github/changelogs/v2.3.0.md
+++ b/.github/changelogs/v2.3.0.md
@@ -12,6 +12,6 @@
 
 - Deprecate _Bootstraps_ class.
 - Accounts from the `AzAuth` class now contain the `meta.url` property, which is the URL of the Azuriom website.
-- Add _MicrosoftAuth.logout()_ method for consistency with other authentication classes.
+- Add `MicrosoftAuth.logout()` method for consistency with other authentication classes.
 - Improve JSDoc.
 

--- a/.github/changelogs/v2.3.5.md
+++ b/.github/changelogs/v2.3.5.md
@@ -1,0 +1,5 @@
+## Changelog
+
+### Bug fixes and improvements
+
+- Export missing `ISkin`, `ICape` and `IAvatar` interfaces.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [<img src="https://img.shields.io/badge/Discord-EML-5561e6?&style=for-the-badge">](https://emlproject.com/discord/github)
 [<img src="https://img.shields.io/badge/platforms-Windows%2C%20macOS%2C%20Linux-0077DA?style=for-the-badge&color=0077DA">](#platforms)
-[<img src="https://img.shields.io/badge/version-2.3.4-orangered?style=for-the-badge&color=orangered">](package.json)
+[<img src="https://img.shields.io/badge/version-2.3.5-orangered?style=for-the-badge&color=orangered">](package.json)
 
 <p>
 <center>

--- a/index.ts
+++ b/index.ts
@@ -34,6 +34,7 @@ type EMLLib = {
 }
 
 export type * from './types/account.js'
+export type * from './types/skin.js'
 export type * from './types/background.js'
 export type * from './types/bootstrap.js'
 export type * from './types/config.js'
@@ -162,7 +163,7 @@ export { Launcher }
  *
  * ---
  *
- * @version 2.3.4
+ * @version 2.3.5
  * @license MIT — See the `LICENSE` file for more information
  * @copyright Copyright (c) 2026, GoldFrite and contributors
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eml-lib",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eml-lib",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "license": "MIT",
       "dependencies": {
         "pngjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eml-lib",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Create your Electron Minecraft Launcher easily!",
   "author": "GoldFrite",
   "license": "MIT",


### PR DESCRIPTION
Prepare release v2.3.5: export missing skin-related interfaces by adding export for ./types/skin, add a new changelog entry (v2.3.5) documenting ISkin/ICape/IAvatar exports, update package.json version and README badge, bump @version in index.ts JSDoc, and apply a minor formatting fix in the v2.3.0 changelog.