### PR TITLE
Add Skin.getSkins/getCapes; deprecate old APIs

### DIFF
--- a/.github/changelogs/v2.3.6.md
+++ b/.github/changelogs/v2.3.6.md
@@ -1,0 +1,7 @@
+## Changelog
+
+### Changes
+
+- Add `Skin.getSkins()` method to retrieve player's skins; deprecate `Skin.getSkin()`.
+- Add `Skin.getCapes()` method to retrieve player's capes; deprecate `Skin.getCape()`.
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [<img src="https://img.shields.io/badge/Discord-EML-5561e6?&style=for-the-badge">](https://emlproject.com/discord/github)
 [<img src="https://img.shields.io/badge/platforms-Windows%2C%20macOS%2C%20Linux-0077DA?style=for-the-badge&color=0077DA">](#platforms)
-[<img src="https://img.shields.io/badge/version-2.3.5-orangered?style=for-the-badge&color=orangered">](package.json)
+[<img src="https://img.shields.io/badge/version-2.3.6-orangered?style=for-the-badge&color=orangered">](package.json)
 
 <p>
 <center>

--- a/index.ts
+++ b/index.ts
@@ -163,7 +163,7 @@ export { Launcher }
  *
  * ---
  *
- * @version 2.3.5
+ * @version 2.3.6
  * @license MIT — See the `LICENSE` file for more information
  * @copyright Copyright (c) 2026, GoldFrite and contributors
  */

--- a/lib/skin/skin.ts
+++ b/lib/skin/skin.ts
@@ -26,6 +26,13 @@ export default class Skin {
   }
 
   /**
+   * @deprecated Use `getSkins()` instead.
+   */
+  async getSkin(): Promise<ISkin[]> {
+    return await this.getSkins()
+  }
+
+  /**
    * Get the player's skin. If the player has no skin, an empty array is returned.
    *
    * **Note:** Data returned by this method may be cached. Call `reload()` to fetch the latest data
@@ -35,9 +42,16 @@ export default class Skin {
    * player). If `false`, all skins are returned, including inactive ones.
    * @returns The list of the player's skins.
    */
-  async getSkin(active: boolean = false): Promise<ISkin[]> {
+  async getSkins(active: boolean = false): Promise<ISkin[]> {
     if (!this.cached) await this.reload()
     return this.skins.filter((skin) => !active || skin.state === 'active')
+  }
+
+  /**
+   * @deprecated Use `getCapes()` instead.
+   */
+  async getCape(active: boolean = false): Promise<ICape[]> {
+    return await this.getCapes(active)
   }
 
   /**
@@ -50,7 +64,7 @@ export default class Skin {
    * player). If `false`, all capes are returned, including inactive ones.
    * @returns The list of the player's capes.
    */
-  async getCape(active: boolean = false): Promise<ICape[]> {
+  async getCapes(active: boolean = false): Promise<ICape[]> {
     if (!this.cached) await this.reload()
     return this.capes.filter((cape) => !active || cape.state === 'active')
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eml-lib",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eml-lib",
-      "version": "2.3.5",
+      "version": "2.3.6",
       "license": "MIT",
       "dependencies": {
         "pngjs": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eml-lib",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "Create your Electron Minecraft Launcher easily!",
   "author": "GoldFrite",
   "license": "MIT",

--- a/test/test.ts
+++ b/test/test.ts
@@ -22,7 +22,7 @@ async function mainWithElectron() {
       const skin = new EMLLib.Skin(account)
 
       console.log('Authenticated account:', account)
-      console.log('Avatar is:', await skin.getAvatar())
+      console.log('Skin is:', await skin.getSkin())
     } catch (err) {
       console.error('Authentication error:', err)
     }
@@ -101,6 +101,6 @@ async function featureTest() {
   console.log(account)
 }
 
-main()
+mainWithElectron()
 
 


### PR DESCRIPTION
Introduce new plural APIs to retrieve multiple assets: add Skin.getSkins() and Skin.getCapes(), and keep deprecated wrappers getSkin() and getCape() that forward to the new methods for backward compatibility. Update tests to call the (deprecated) wrapper and run the Electron test entry, and bump the package version to 2.3.6 (also update README badge and index.ts @version). Add a changelog entry documenting the new methods and deprecations.